### PR TITLE
Add tagging to the library

### DIFF
--- a/fore/foresight/client.py
+++ b/fore/foresight/client.py
@@ -1,4 +1,5 @@
 """The main client class for the foresight API."""
+from collections import defaultdict
 import importlib.util
 import uuid
 import logging
@@ -36,7 +37,7 @@ class Foresight:
         self.max_entries_before_auto_flush = max_entries_before_auto_flush
 
         self.timeout_seconds = 60
-        self.log_entries = []
+        self.tag_to_log_entries = defaultdict(list)
         logging.basicConfig(format="foresight %(levelname)s: %(message)s",
                             level=log_level)
         logging.info("Foresight client initialized")
@@ -192,31 +193,42 @@ class Foresight:
 
         Returns: The HTTP response on success or raises an HTTPError on failure.
         """
-        if not self.log_entries:
+        has_entries_to_flush = any(
+            len(entries) > 0 for entries in self.tag_to_log_entries.values())
+
+        if not has_entries_to_flush:
             logging.info("No log entries to flush.")
             return
 
-        log_request = LogRequest(log_entries=self.log_entries)
-        response = self.__make_request(
-            method="put",
-            endpoint="/api/eval/log",
-            input_json=log_request.model_dump(mode="json"))
+        for tag, log_entries in self.tag_to_log_entries.items():
+            log_request = LogRequest(
+                log_entries=log_entries,
+                tag=(tag if tag != "default" else None))
+            response = self.__make_request(
+                method="put",
+                endpoint="/api/eval/log",
+                input_json=log_request.model_dump(mode="json"))
 
-        if response.status_code == 200:
-            logging.info(
-                "Log entries flushed successfully. Visit %s to view results.",
-                self.ui_url)
-            # Clear log entries after flushing
-            self.log_entries.clear()
-        else:
-            logging.error(
-                "Flushing log entries failed with response code: %s",
-                response.status_code
-            )
+            if response.status_code == 200:
+                logging.info(
+                    "Log entries flushed successfully for %s."
+                    " Visit %s to view results.",
+                    tag, self.ui_url)
+                # Clear log entries after flushing
+                log_entries.clear()
+            else:
+                logging.error(
+                    "Flushing log entries failed with response code: %s",
+                    response.status_code
+                )
 
         return response
 
-    def log(self, query: str, response: str, contexts: list[str]) -> None:
+    def log(self,
+            query: str,
+            response: str,
+            contexts: list[str],
+            tag: str | None = None) -> None:
         """Add log entries for evaluation. This only adds the entries
         in memory, but does not send any requests to foresight service.
         To send the request, flush needs to be called.
@@ -229,13 +241,18 @@ class Foresight:
             query: The query for evaluation.
             response: The response from your AI system.
             contexts: List of contexts relevant to the query.
+            tag: An optional tag for the request. e.g. "great-model-v01".
+                This will be prepended to the name of the eval run
+                (experiment_id). The complete eval run experiment_id will be
+                of the form: "great-model-v01_logs_groundedness_YYYYMMDD"
         """
         inference_output = InferenceOutput(
             generated_response=response, contexts=contexts)
         log_entry = LogTuple(query=query, inference_output=inference_output)
-        self.log_entries.append(log_entry)
-        if len(self.log_entries) >= self.max_entries_before_auto_flush:
-            # Auto flush if the number of entries is greater than a
+        tag = tag if tag else "default"
+        self.tag_to_log_entries[tag].append(log_entry)
+        if len(self.tag_to_log_entries[tag]) >= self.max_entries_before_auto_flush:
+            # Auto flush if the number of entries for any tag is greater than a
             # certain threshold.
             self.flush()
 

--- a/fore/foresight/client.py
+++ b/fore/foresight/client.py
@@ -251,8 +251,9 @@ class Foresight:
             generated_response=response, contexts=contexts)
         log_entry = LogTuple(query=query, inference_output=inference_output)
         tag = tag if tag else DEFAULT_TAG_NAME
-        self.tag_to_log_entries[tag].append(log_entry)
-        if len(self.tag_to_log_entries[tag]) >= self.max_entries_before_auto_flush:
+        entries_for_tag = self.tag_to_log_entries[tag]
+        entries_for_tag.append(log_entry)
+        if (len(entries_for_tag) >= self.max_entries_before_auto_flush):
             # Auto flush if the number of entries for any tag is greater than a
             # certain threshold.
             self.flush()

--- a/fore/foresight/client.py
+++ b/fore/foresight/client.py
@@ -20,6 +20,7 @@ GenerateFnT = Callable[[str], InferenceOutput]
 GATEWAY_URL = "https://foresight-gateway.foreai.co"
 UI_URL = "https://foresight.foreai.co"
 MAX_ENTRIES_BEFORE_FLUSH = 10
+DEFAULT_TAG_NAME = "default"
 
 
 class Foresight:
@@ -203,7 +204,7 @@ class Foresight:
         for tag, log_entries in self.tag_to_log_entries.items():
             log_request = LogRequest(
                 log_entries=log_entries,
-                tag=(tag if tag != "default" else None))
+                tag=(tag if tag != DEFAULT_TAG_NAME else None))
             response = self.__make_request(
                 method="put",
                 endpoint="/api/eval/log",
@@ -249,7 +250,7 @@ class Foresight:
         inference_output = InferenceOutput(
             generated_response=response, contexts=contexts)
         log_entry = LogTuple(query=query, inference_output=inference_output)
-        tag = tag if tag else "default"
+        tag = tag if tag else DEFAULT_TAG_NAME
         self.tag_to_log_entries[tag].append(log_entry)
         if len(self.tag_to_log_entries[tag]) >= self.max_entries_before_auto_flush:
             # Auto flush if the number of entries for any tag is greater than a

--- a/fore/foresight/client.py
+++ b/fore/foresight/client.py
@@ -253,7 +253,7 @@ class Foresight:
         tag = tag if tag else DEFAULT_TAG_NAME
         entries_for_tag = self.tag_to_log_entries[tag]
         entries_for_tag.append(log_entry)
-        if (len(entries_for_tag) >= self.max_entries_before_auto_flush):
+        if len(entries_for_tag) >= self.max_entries_before_auto_flush:
             # Auto flush if the number of entries for any tag is greater than a
             # certain threshold.
             self.flush()

--- a/fore/foresight/client_test.py
+++ b/fore/foresight/client_test.py
@@ -395,9 +395,11 @@ class TestForeSight(unittest.TestCase):
             )
         ]
 
+        mock_request.assert_has_calls(expected_calls, any_order=True)
+
         # Assert that log_entries is empty after flushing
         self.assertDictEqual(
-            self.client.tag_to_log_entries, {"default": [], 'great_model': []})
+            self.client.tag_to_log_entries, {"default": [], "great_model": []})
 
         # Assert the response from flush
         self.assertEqual(response1.status_code, 200)

--- a/fore/foresight/client_test.py
+++ b/fore/foresight/client_test.py
@@ -1,7 +1,7 @@
 """Tests for the client class."""
 import unittest
 from typing import Any, Dict
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, call, patch
 
 import pandas as pd
 
@@ -259,47 +259,83 @@ class TestForeSight(unittest.TestCase):
         llm_response3 = "test_response3"
         contexts3 = ["context5", "context6"]
 
+        query4 = "test_query4"
+        llm_response4 = "test_response4"
+        contexts4 = ["context7", "context8"]
+
         self.client.log(query1, llm_response1, contexts1)
+        self.client.log(query4, llm_response4, contexts4, tag="great_model")
         self.client.log(query2, llm_response2, contexts2)
         self.client.log(query3, llm_response3, contexts3)
 
-        mock_request.assert_called_with(
-            method="put",
-            url=f"{TEST_URL}/api/eval/log",
-            headers={"Authorization": f"Bearer {TEST_TOKEN}"},
-            params=None,
-            json={
-                "log_entries": [
-                    {
-                        "query": "test_query1",
-                        "inference_output": {
-                            "generated_response": "test_response1",
-                            "source_docids": None,
-                            "contexts": ["context1", "context2"],
-                            "debug_info": None
+        expected_calls = [
+            call(
+                method="put",
+                url=f"{TEST_URL}/api/eval/log",
+                headers={"Authorization": f"Bearer {TEST_TOKEN}"},
+                params=None,
+                json={
+                    "log_entries": [
+                        {
+                            "query": "test_query1",
+                            "inference_output": {
+                                "generated_response": "test_response1",
+                                "source_docids": None,
+                                "contexts": ["context1", "context2"],
+                                "debug_info": None
+                            }
+                        },
+                        {
+                            "query": "test_query2",
+                            "inference_output": {
+                                "generated_response": "test_response2",
+                                "source_docids": None,
+                                "contexts": ["context3", "context4"],
+                                "debug_info": None
+                            }
                         }
-                    },
-                    {
-                        "query": "test_query2",
-                        "inference_output": {
-                            "generated_response": "test_response2",
-                            "source_docids": None,
-                            "contexts": ["context3", "context4"],
-                            "debug_info": None
-                        }
-                    }
-                ]
-            },
-            timeout=TEST_TIMEOUT)
+                    ],
+                    "tag": None
+                },
+                timeout=TEST_TIMEOUT
+            ),
+            call(
+                method="put",
+                url=f"{TEST_URL}/api/eval/log",
+                headers={"Authorization": f"Bearer {TEST_TOKEN}"},
+                params=None,
+                json={
+                    "log_entries": [
+                        {
+                            "query": "test_query4",
+                            "inference_output": {
+                                "generated_response": "test_response4",
+                                "source_docids": None,
+                                "contexts": ["context7", "context8"],
+                                "debug_info": None
+                            }
+                        },
+                    ],
+                    "tag": "great_model"
+                },
+                timeout=TEST_TIMEOUT
+            )
+        ]
 
-        self.assertEqual(len(self.client.log_entries), 1)
-        self.assertListEqual(
-            self.client.log_entries,
-            [LogTuple(
+        mock_request.assert_has_calls(expected_calls, any_order=True)
+
+        self.assertEqual(len(self.client.tag_to_log_entries), 2)
+        self.assertDictEqual(
+            self.client.tag_to_log_entries,
+            {"default":
+             [
+                 LogTuple(
                 query="test_query3",
                 inference_output=InferenceOutput(
                     generated_response="test_response3",
-                    contexts=["context5", "context6"]))])
+                    contexts=["context5", "context6"]))
+             ],
+             "great_model": []})
 
     @patch("requests.request")
     def test_flush_sends_request_and_clears_entries(self, mock_request):
@@ -308,35 +344,64 @@ class TestForeSight(unittest.TestCase):
         mock_response.status_code = 200
         mock_request.return_value = mock_response
 
-        # Add some log entries
+        # Add some log entries and flush
         self.client.log("test_query1", "test_response1", ["context1"])
-
-        response = self.client.flush()
-        mock_request.assert_called_with(
-            method="put",
-            url=f"{TEST_URL}/api/eval/log",
-            headers={"Authorization": f"Bearer {TEST_TOKEN}"},
-            params=None,
-            json={
-                "log_entries": [
-                    {
-                        "query": "test_query1",
-                        "inference_output": {
-                            "generated_response": "test_response1",
-                            "source_docids": None,
-                            "contexts": ["context1"],
-                            "debug_info": None
+        response1 = self.client.flush()
+        self.client.log("test_query2", "test_response2",
+                        ["context2"], tag="great_model")
+        response2 = self.client.flush()
+        expected_calls = [
+            call(
+                method="put",
+                url=f"{TEST_URL}/api/eval/log",
+                headers={"Authorization": f"Bearer {TEST_TOKEN}"},
+                params=None,
+                json={
+                    "log_entries": [
+                        {
+                            "query": "test_query1",
+                            "inference_output": {
+                                "generated_response": "test_response1",
+                                "source_docids": None,
+                                "contexts": ["context1"],
+                                "debug_info": None
+                            }
                         }
-                    }
-                ]
-            },
-            timeout=TEST_TIMEOUT)
+                    ],
+                    "tag": None
+                },
+                timeout=TEST_TIMEOUT
+            ),
+            call(
+                method="put",
+                url=f"{TEST_URL}/api/eval/log",
+                headers={"Authorization": f"Bearer {TEST_TOKEN}"},
+                params=None,
+                json={
+                    "log_entries": [
+                        {
+                            "query": "test_query2",
+                            "inference_output": {
+                                "generated_response": "test_response2",
+                                "source_docids": None,
+                                "contexts": ["context2"],
+                                "debug_info": None
+                            }
+                        },
+                    ],
+                    "tag": "great_model"
+                },
+                timeout=TEST_TIMEOUT
+            )
+        ]
 
         # Assert that log_entries is empty after flushing
-        self.assertEqual(len(self.client.log_entries), 0)
+        self.assertDictEqual(
+            self.client.tag_to_log_entries, {"default": [], 'great_model': []})
 
         # Assert the response from flush
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response1.status_code, 200)
+        self.assertEqual(response2.status_code, 200)
 
     @staticmethod
     def get_evalrun_details_sample(

--- a/fore/foresight/schema.py
+++ b/fore/foresight/schema.py
@@ -142,3 +142,8 @@ class LogTuple(BaseModel):
 class LogRequest(BaseModel):
     """Request to log query and inference outputs."""
     log_entries: list[LogTuple]
+    # e.g. "great-model-v01". This will be prepended to the
+    # name of the eval run (experiment_id).
+    # The complete eval run experiment_id will be of the form:
+    #   "great-model-v01_logs_groundedness_YYYYMMDD"
+    tag: str | None = None


### PR DESCRIPTION
- Allows users to additionally specify a tag to the log entries.
- The eval run names (aka experiment_id's) are then prepended with this prefix